### PR TITLE
Create layout for easily deleting website users over the API

### DIFF
--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -89,10 +89,9 @@
             deleteButton: 'Kustuta',
             confirmText: 'Oled sa kindel, et soovid seda kasutajat kustutada?',
             userDeleted: 'Kasutaja kustutatud!',
-            userExists: 'Kasutaja on juba olemas!',
             userAdded: 'Kasutaja lisatud!',
             userNotInserted: "E-posti aadressi ei ole sisestatud!",
-            notValidEmail: "Sisestatud e-posti aadress on ebasobiv!",
+            notCorrectOrAlreadyExists: "E-posti aadress pole korrektne või on juba lisatud!",
             somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
           },
           'en': {
@@ -101,10 +100,9 @@
             deleteButton: 'Delete',
             confirmText: 'Are you sure you want to delete this account?',
             userDeleted: 'User deleted!',
-            userExists: 'User already exists!',
             userAdded: 'User added!',
             userNotInserted: "E-mail address is not inserted",
-            notValidEmail: "The entered e-mail address is not valid!",
+            notCorrectOrAlreadyExists: "The entered e-mail address is not valid or already exists!",
             somethingWentWrong: "Something went wrong, try again!"
           }
         }
@@ -123,7 +121,7 @@
 
         const addUser = () => {
           const emailAddressToAdd = $('#email-to-add')[0].value;
-          const regexp = /^([\w\d._\-#])+@([\w\d._\-#]+[.][\w\d._\-#]+)+$/;
+          const regexp = /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i;
 
           if (emailAddressToAdd === '') {
             alert(tr('userNotInserted'));
@@ -141,13 +139,11 @@
               })
               .catch(function (xhr) {
                 if (typeof xhr.responseJSON.errors.email !== 'undefined') {
-                  alert(tr('userExists'));
+                  alert(tr('notCorrectOrAlreadyExists'));
                 }
               });
-          } else if (!emailAddressToAdd.match(regexp)) {
-            alert(tr('notValidEmail'))
           } else {
-            alert(tr('somethingWentWrong'));
+            alert(tr('notCorrectOrAlreadyExists'));
           }
         }
 

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -91,7 +91,7 @@
           </div>
 
           <div class="user-list">
-            <table id='user-table-table'>
+            <table id='user-table'>
               <thead>
                 <tr>
                   <th>{{str_email_address | escape_once}}</th>
@@ -99,7 +99,7 @@
                   <th>{{str_user_activated | escape_once}}</th>
                 </tr>
               </thead>
-              <tbody id='user-table'>
+              <tbody id='user-table-body'>
               </tbody>
             </table>
           </div>
@@ -137,7 +137,7 @@
           const target = e.target || e.srcElement;
           const value = target.value.toLowerCase();
 
-          $('#user-table tr').each(function () {
+          $('#user-table-body tr').each(function () {
             $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
           });
         }
@@ -173,15 +173,17 @@
         const getAllUsers = () => {
           let promises = [];
 
-          getUsersPage().then((obj) => {
-            const nPages = obj.nPages;
+          getUsersPage().then((usersPage) => {
+            const nPages = usersPage.nPages;
 
-            for (let i = 1; i <= nPages; i++) {
+            for (let i = 2; i <= nPages; i++) {
               promises.push(getUsersPage(i));
             }
+            
+            addToTable(usersPage.users, {init: true});
 
             Promise.all(promises).then((results) => {
-              results.forEach((obj, idx) => addToTable(obj.users, {init: idx === 1}));
+              results.forEach((usersPage, idx) => addToTable(usersPage.users));
             });
           })
         }
@@ -194,9 +196,9 @@
               dataType: 'json',
             })
             .then((users, status, xhr) => {
-              const pages = parseInt(xhr.getResponseHeader('X-Total-Pages'));
+              const nPages = parseInt(xhr.getResponseHeader('X-Total-Pages'));
 
-              resolve({users: users, nPages: pages});          
+              resolve({users, nPages});          
             })
             .catch(xhr => {
               alert(tr('somethingWentWrong'));
@@ -204,14 +206,14 @@
             });
         });
 
-        const addToTable = (users, init = false) => {
+        const addToTable = (users, {init = false} = {}) => {
 
           if (init) {
-            $('#user-table').empty();
+            $('#user-table-body').empty();
           }
 
           users.forEach((user) => {
-            $('#user-table').append(`<tr>
+            $('#user-table-body').append(`<tr>
                             <td>${user.email}</td>
                             <td class='text-center'>
                               <button class='delete' data-id='${user.id}'>

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -2,234 +2,228 @@
   <!DOCTYPE html>
   {% include "template-variables" %}
   <html class="{% if editmode %}editmode{% else %}public{% endif %}" lang="{{ page.language_code }}">
-
-  <head prefix="og: http://ogp.me/ns#">
-    {% include "html-head" %}
-    <style>
-      .container .content {
-        font-size: 16px;
-      }
-
-      td,
-      th {
-        border: 1px solid #dddddd;
-        padding: 8px;
-        text-align: left;
-      }
-
-      table {
-        table-layout: fixed;
-        border-collapse: collapse;
-      }
-
-      .user-list {
-        padding-top: 16px;
-      }
-
-      .search-user {
-        padding-top: 32px;
-      }
-    </style>
-
-    {% if editmode or site.has_many_languages? %}
-    {% assign lang-enabled = "lang-enabled" %}
-    {% endif %}
-
-    {% if flags_state %}
-    {% assign flags="flags-enabled" %}
-    {% else %}
-    {% assign flags="flags-disabled" %}
-    {% endif %}
-
-    {% if editor_locale == 'et' %}
-    {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
-    {% assign str_add = "Lisa" %}
-    {% assign str_search_email = "Soovid otsida kasutajat? " %}
-    {% assign str_insert_email = "Sisesta e-posti aadress" %}
-    {% else %}
-    {% assign str_add_email = "Add an e-mail address: " %}
-    {% assign str_add = "Add" %}
-    {% assign str_search_email = "Search for an e-mail: " %}
-    {% assign str_insert_email = "Insert an e-mail" %}
-    {% endif %}
-
-  </head>
-
-  <body class="content-page {{ lang-enabled }} {{ flags }}">
-    <div class="container">
-      {% include "header" %}
-
-      <section class="content-header content-formatted cfx"></section>
-
-      <main class="content" role="main">
-
-        <div class="add-user">
-          <label for="email">{{ str_add_email }}</label>
-          <input type="email" id="email-to-add" name="email" placeholder="email@email.com">
-
-          <input type="submit" value="{{ str_add }}" id="add-user"><br>
-        </div>
-
-
-        <div class="search-user">
-          <label for="search">{{ str_search_email }}</label>
-          <input id="search" type="text" placeholder="{{ str_insert_email }}" />
-        </div>
-
-        <div class="user-list"></div>
-
-      </main>
-      {% include "footer" %}
-    </div>
-
-    {%- comment -%} Included component name can differ depending on template {%- endcomment -%}
-    {% include "javascripts" %}
-
-    <script>
-      const translationStrings = {
-        'et': {
-          emailAddress: 'E-posti aadress',
-          deleteUser: 'Kustuta kasutaja',
-          deleteButton: 'Kustuta',
-          confirmText: 'Oled sa kindel, et soovid seda kasutajat kustutada?',
-          userDeleted: 'Kasutaja kustutatud!',
-          userExists: 'Kasutaja on juba olemas!',
-          userAdded: 'Kasutaja lisatud!',
-          userNotInserted: "E-posti aadressi ei ole sisestatud!",
-          notValidEmail: "Sisestatud e-posti aadress on ebasobiv!",
-          somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
-        },
-        'en': {
-          emailAddress: 'E-mail address',
-          deleteUser: 'Delete user',
-          deleteButton: 'Delete',
-          confirmText: 'Are you sure you want to delete this account?',
-          userDeleted: 'User deleted!',
-          userExists: 'User already exists!',
-          userAdded: 'User added!',
-          userNotInserted: "E-mail address is not inserted",
-          notValidEmail: "The entered e-mail address is not valid!",
-          somethingWentWrong: "Something went wrong, try again!"
+    <head prefix="og: http://ogp.me/ns#">
+      {% include "html-head" %}
+      <style>
+        .container .content {
+          font-size: 16px;
         }
-      }
 
-      const language = document.getElementsByTagName('html')[0].getAttribute('lang');
-      const tr = key => (translationStrings[language] || {})[key];
-
-      const translatedDeleteButton = tr('deleteButton');
-
-      const searchTable = (e) => {
-        const target = (e.target) ? e.target : e.srcElement;
-        const value = target.value.toLowerCase();
-        $('#user-table tr').each(function () {
-          $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
-        });
-      }
-
-      const addUser = () => {
-        const emailAddressToAdd = $('#email-to-add')[0].value;
-        const regexp = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/;
-
-        if (emailAddressToAdd.match(regexp)) {
-          $.ajax({
-              type: 'POST',
-              contentType: 'application/json',
-              url: '/admin/api/site_users',
-              dataType: 'json',
-              data: `{\"email\" : \"${emailAddressToAdd}\"}`,
-            })
-            .then(function () {
-              alert(tr('userAdded'))
-              getUsers().then(buildTable);
-            })
-            .catch(function (xhr) {
-              if (xhr.responseJSON.errors.email[0] === "has already been taken") {
-                alert(tr('userExists'));
-              }
-            });
-        } else if (emailAddressToAdd === '') {
-          alert(tr('userNotInserted'));
-        } else {
-          alert(tr('notValidEmail'));
+        td,
+        th {
+          border: 1px solid #dddddd;
+          padding: 8px;
+          text-align: left;
         }
-      }
 
-      const getUsers = () => new Promise((resolve, reject) => {
-        $.ajax({
-            type: 'GET',
-            contentType: 'application/json',
-            url: '/admin/api/site_users',
-            dataType: 'json'
-          })
-          .then(users => {
-            users.forEach((user) => {
-              [].push(user)
-            });
-            resolve(users);
-          })
-          .catch(xhr => {
-            alert(tr('somethingWentWrong'));
-            reject();
-          })
-      });
+        table {
+          table-layout: fixed;
+          border-collapse: collapse;
+        }
 
-      const buildTable = users => {
-        let list_html = `<table>
-                    <thead>
-                      <tr>
-                        <th>${tr('emailAddress')}</th>
-                        <th>${tr('deleteUser')}</th>
-                      </tr>
-                    </thead>`;
+        .user-list {
+          padding-top: 16px;
+        }
 
-        users.forEach((user) => {
-          list_html += `<tbody id='user-table'>
-                    <tr>
-                      <td>
-                        ${user.email}
-                      </td>
-                      <td>
-                        <button class='delete' data-id='${user.id}'>
-                          ${translatedDeleteButton}
-                        </button>
-                      </td>
-                    </tr>`;
-        });
+        .search-user {
+          padding-top: 32px;
+        }
+      </style>
 
-        list_html += '</tbody></table>';
-        $('.user-list').html(list_html);
-      };
+      {% if editmode or site.has_many_languages? %}
+        {% assign lang-enabled = "lang-enabled" %}
+      {% endif %}
 
-      getUsers().then(buildTable);
+      {% if flags_state %}
+        {% assign flags="flags-enabled" %}
+      {% else %}
+        {% assign flags="flags-disabled" %}
+      {% endif %}
 
-      const deleteUser = (e) => {
-        const target = (e.target) ? e.target : e.srcElement;
-        const id = $(target)[0].attributes['data-id'].value;
+      {% if editor_locale == 'et' %}
+        {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
+        {% assign str_add = "Lisa" %}
+        {% assign str_search_email = "Soovid otsida kasutajat? " %}
+        {% assign str_insert_email = "Sisesta e-posti aadress" %}
+      {% else %}
+        {% assign str_add_email = "Add an e-mail address: " %}
+        {% assign str_add = "Add" %}
+        {% assign str_search_email = "Search for an e-mail: " %}
+        {% assign str_insert_email = "Insert an e-mail" %}
+      {% endif %}
 
-        if (confirm(tr('confirmText'))) {
-          $.ajax({
-            type: 'DELETE',
-            contentType: 'application/json',
-            url: `/admin/api/site_users/${id}`,
-            dataType: 'json'
-          }).then(function () {
-            getUsers().then(buildTable);
-            alert(tr('userDeleted'))
-          }).catch(function () {
-            alert(tr('somethingWentWrong'));
+    </head>
+
+    <body class="content-page {{ lang-enabled }} {{ flags }}">
+      <div class="container">
+        {% include "header" %}
+
+        <section class="content-header content-formatted cfx"></section>
+
+        <main class="content" role="main">
+
+          <div class="add-user">
+            <label for="email">{{ str_add_email }}</label>
+            <input type="email" id="email-to-add" name="email" placeholder="email@email.com">
+
+            <input type="submit" value="{{ str_add }}" id="add-user"><br>
+          </div>
+
+
+          <div class="search-user">
+            <label for="search">{{ str_search_email }}</label>
+            <input id="search" type="text" placeholder="{{ str_insert_email }}" />
+          </div>
+
+          <div class="user-list"></div>
+
+        </main>
+        {% include "footer" %}
+      </div>
+
+      {%- comment -%} Included component name can differ depending on template {%- endcomment -%}
+      {% include "javascripts" %}
+
+      <script>
+        const translationStrings = {
+          'et': {
+            emailAddress: 'E-posti aadress',
+            deleteUser: 'Kustuta kasutaja',
+            deleteButton: 'Kustuta',
+            confirmText: 'Oled sa kindel, et soovid seda kasutajat kustutada?',
+            userDeleted: 'Kasutaja kustutatud!',
+            userExists: 'Kasutaja on juba olemas!',
+            userAdded: 'Kasutaja lisatud!',
+            userNotInserted: "E-posti aadressi ei ole sisestatud!",
+            notValidEmail: "Sisestatud e-posti aadress on ebasobiv!",
+            somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
+          },
+          'en': {
+            emailAddress: 'E-mail address',
+            deleteUser: 'Delete user',
+            deleteButton: 'Delete',
+            confirmText: 'Are you sure you want to delete this account?',
+            userDeleted: 'User deleted!',
+            userExists: 'User already exists!',
+            userAdded: 'User added!',
+            userNotInserted: "E-mail address is not inserted",
+            notValidEmail: "The entered e-mail address is not valid!",
+            somethingWentWrong: "Something went wrong, try again!"
+          }
+        }
+
+        const language = document.getElementsByTagName('html')[0].getAttribute('lang');
+        const tr = key => (translationStrings[language] || {})[key];
+
+        const translatedDeleteButton = tr('deleteButton');
+
+        const searchTable = (e) => {
+          const target = e.target || e.srcElement;
+          const value = target.value.toLowerCase();
+          $('#user-table tr').each(function () {
+            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
           });
         }
-      }
 
-      const init = () => $(document).ready(() => {
-        $('#search').on('keyup', searchTable);
-        $(document).on('click', '.delete', deleteUser);
-        $(document).on('click', '#add-user', addUser);
-      });
+        const addUser = () => {
+          const emailAddressToAdd = $('#email-to-add')[0].value;
+          const regexp = /^([\w\d._\-#])+@([\w\d._\-#]+[.][\w\d._\-#]+)+$/;
 
-      init();
-    </script>
-  </body>
+          if (emailAddressToAdd === '') {
+            alert(tr('userNotInserted'));
+          } else if (emailAddressToAdd.match(regexp)) {
+            $.ajax({
+                type: 'POST',
+                contentType: 'application/json',
+                url: '/admin/api/site_users',
+                dataType: 'json',
+                data: JSON.stringify({email: emailAddressToAdd}),
+              })
+              .then(function () {
+                alert(tr('userAdded'))
+                getUsers().then(buildTable);
+              })
+              .catch(function (xhr) {
+                if (typeof xhr.responseJSON.errors.email !== 'undefined') {
+                  alert(tr('userExists'));
+                }
+              });
+          } else {
+            alert(tr('somethingWentWrong'));
+          }
+        }
+
+        const getUsers = () => new Promise((resolve, reject) => {
+          $.ajax({
+              type: 'GET',
+              contentType: 'application/json',
+              url: '/admin/api/site_users',
+              dataType: 'json'
+            })
+            .then(users => {
+              resolve(users);
+            })
+            .catch(xhr => {
+              alert(tr('somethingWentWrong'));
+              reject();
+            })
+        });
+
+        const buildTable = users => {
+          let list_html = `<table>
+                      <thead>
+                        <tr>
+                          <th>${tr('emailAddress')}</th>
+                          <th>${tr('deleteUser')}</th>
+                        </tr>
+                      </thead>
+                        <tbody id='user-table'>`;
+
+          users.forEach((user) => {
+            list_html += `<tr>
+                            <td>${user.email}</td>
+                            <td>
+                              <button class='delete' data-id='${user.id}'>
+                                ${translatedDeleteButton}
+                              </button>
+                            </td>
+                          </tr>`;
+          });
+
+          list_html += '</tbody></table>';
+          $('.user-list').html(list_html);
+        };
+
+        const deleteUser = (e) => {
+          const target = e.target || e.srcElement;
+          const entry = target.closest('tr');
+          const id = $(target)[0].attributes['data-id'].value;
+
+          if (confirm(tr('confirmText'))) {
+            $.ajax({
+              type: 'DELETE',
+              contentType: 'application/json',
+              url: `/admin/api/site_users/${id}`,
+              dataType: 'json'
+            }).then(function () {
+              entry.remove();
+              alert(tr('userDeleted'))
+            }).catch(function () {
+              alert(tr('somethingWentWrong'));
+            });
+          }
+        }
+
+        const init = () => $(document).ready(() => {
+          getUsers().then(buildTable);
+          $('#search').on('keyup', searchTable);
+          $(document).on('click', '.delete', deleteUser);
+          $(document).on('click', '#add-user', addUser);
+        });
+
+        init();
+      </script>
+    </body>
 
   </html>
 {% else %}

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -10,15 +10,11 @@
         font-size: 16px;
       }
 
-      tr {
-        height: 100%;
-      }
-
       td,
       th {
         border: 1px solid #dddddd;
         padding: 8px;
-        text-align: center;
+        text-align: left;
       }
 
       table {
@@ -34,28 +30,27 @@
         padding-top: 32px;
       }
     </style>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
     {% if editmode or site.has_many_languages? %}
-      {% assign lang-enabled = "lang-enabled" %}
+    {% assign lang-enabled = "lang-enabled" %}
     {% endif %}
 
     {% if flags_state %}
-      {% assign flags="flags-enabled" %}
+    {% assign flags="flags-enabled" %}
     {% else %}
-      {% assign flags="flags-disabled" %}
+    {% assign flags="flags-disabled" %}
     {% endif %}
 
     {% if editor_locale == 'et' %}
-      {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
-      {% assign str_add = "Lisa" %}
-      {% assign str_search_email = "Soovid otsida kasutajat? " %}
-      {% assign str_insert_email = "Sisesta e-posti aadress" %}
+    {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
+    {% assign str_add = "Lisa" %}
+    {% assign str_search_email = "Soovid otsida kasutajat? " %}
+    {% assign str_insert_email = "Sisesta e-posti aadress" %}
     {% else %}
-      {% assign str_add_email = "Add an e-mail address: " %}
-      {% assign str_add = "Add" %}
-      {% assign str_search_email = "Search for an e-mail: " %}
-      {% assign str_insert_email = "Insert an e-mail" %}
+    {% assign str_add_email = "Add an e-mail address: " %}
+    {% assign str_add = "Add" %}
+    {% assign str_search_email = "Search for an e-mail: " %}
+    {% assign str_insert_email = "Insert an e-mail" %}
     {% endif %}
 
   </head>
@@ -67,8 +62,8 @@
       <section class="content-header content-formatted cfx"></section>
 
       <main class="content" role="main">
-        <div class="add-user">
 
+        <div class="add-user">
           <label for="email">{{ str_add_email }}</label>
           <input type="email" id="email-to-add" name="email" placeholder="email@email.com">
 
@@ -77,10 +72,8 @@
 
 
         <div class="search-user">
-
           <label for="search">{{ str_search_email }}</label>
           <input id="search" type="text" placeholder="{{ str_insert_email }}" />
-
         </div>
 
         <div class="user-list"></div>
@@ -89,163 +82,153 @@
       {% include "footer" %}
     </div>
 
+    {%- comment -%} Included component name can differ depending on template {%- endcomment -%}
+    {% include "javascripts" %}
 
     <script>
-      // Translations for the JS part
       const translationStrings = {
-          'et': {
-              emailAddress: 'E-posti aadress',
-              deleteUser: 'Kustuta kasutaja',
-              deleteButton: 'Kustuta',
-              confirmText: 'Oled sa kindel, et soovid seda kasutajat kustutada?',
-              userDeleted: 'Kasutaja kustutatud!',
-              userExists: 'Kasutaja on juba olemas!',
-              userAdded: 'Kasutaja lisatud!',
-              userNotInserted: "E-posti aadressi ei ole sisestatud!",
-              notValidEmail: "Sisestatud e-posti aadress on ebasobiv!",
-              somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
-          },
-          'en': {
-              emailAddress: 'E-mail address',
-              deleteUser: 'Delete user',
-              deleteButton: 'Delete',
-              confirmText: 'Are you sure you want to delete this account?',
-              userDeleted: 'User deleted!',
-              userExists: 'User already exists!',
-              userAdded: 'User added!',
-              userNotInserted: "E-mail address is not inserted",
-              notValidEmail: "The entered e-mail address is not valid!",
-              somethingWentWrong: "Something went wrong, try again!"
-          }
+        'et': {
+          emailAddress: 'E-posti aadress',
+          deleteUser: 'Kustuta kasutaja',
+          deleteButton: 'Kustuta',
+          confirmText: 'Oled sa kindel, et soovid seda kasutajat kustutada?',
+          userDeleted: 'Kasutaja kustutatud!',
+          userExists: 'Kasutaja on juba olemas!',
+          userAdded: 'Kasutaja lisatud!',
+          userNotInserted: "E-posti aadressi ei ole sisestatud!",
+          notValidEmail: "Sisestatud e-posti aadress on ebasobiv!",
+          somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
+        },
+        'en': {
+          emailAddress: 'E-mail address',
+          deleteUser: 'Delete user',
+          deleteButton: 'Delete',
+          confirmText: 'Are you sure you want to delete this account?',
+          userDeleted: 'User deleted!',
+          userExists: 'User already exists!',
+          userAdded: 'User added!',
+          userNotInserted: "E-mail address is not inserted",
+          notValidEmail: "The entered e-mail address is not valid!",
+          somethingWentWrong: "Something went wrong, try again!"
+        }
       }
 
-      let language = document.getElementsByTagName('html')[0].getAttribute('lang');
-      let tr = key => (translationStrings[language] || {})[key];
+      const language = document.getElementsByTagName('html')[0].getAttribute('lang');
+      const tr = key => (translationStrings[language] || {})[key];
 
-      const translatedEmailAddress = tr('emailAddress');
-      const translatedDeleteUser = tr('deleteUser');
       const translatedDeleteButton = tr('deleteButton');
-      const translatedConfirmText = tr('confirmText');
-      const translatedUserDeleted = tr('userDeleted');
-      const translatedUserExists = tr('userExists');
-      const translatedUserAdded = tr('userAdded');
-      const translatedUserNotInserted = tr('userNotInserted');
-      const translatedNotValidEmail = tr('notValidEmail');
-      const translatedSomethingWentWrong = tr('somethingWentWrong');
 
-      let allUsers = [];
+      const searchTable = (e) => {
+        const target = (e.target) ? e.target : e.srcElement;
+        const value = target.value.toLowerCase();
+        $('#user-table tr').each(function () {
+          $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+        });
+      }
 
-      /* Filter the table during searching */
-      $(document).ready(function () {
-          $('#search').on('keyup', function () {
+      const addUser = () => {
+        const emailAddressToAdd = $('#email-to-add')[0].value;
+        const regexp = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/;
 
-              const value = $(this).val().toLowerCase();
-
-              $('#user-table tr').each(function () {
-                  $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
-              });
-          });
-      });
-
-      /* Add all the users to the table based on a GET-request */
-      function getUsers() {
+        if (emailAddressToAdd.match(regexp)) {
           $.ajax({
-              type: 'GET',
+              type: 'POST',
               contentType: 'application/json',
               url: '/admin/api/site_users',
-              dataType: 'json'
-          }).then(function (users) {
+              dataType: 'json',
+              data: `{\"email\" : \"${emailAddressToAdd}\"}`,
+            })
+            .then(function () {
+              alert(tr('userAdded'))
+              getUsers().then(buildTable);
+            })
+            .catch(function (xhr) {
+              if (xhr.responseJSON.errors.email[0] === "has already been taken") {
+                alert(tr('userExists'));
+              }
+            });
+        } else if (emailAddressToAdd === '') {
+          alert(tr('userNotInserted'));
+        } else {
+          alert(tr('notValidEmail'));
+        }
+      }
 
-              // Make a table
+      const getUsers = () => new Promise((resolve, reject) => {
+        $.ajax({
+            type: 'GET',
+            contentType: 'application/json',
+            url: '/admin/api/site_users',
+            dataType: 'json'
+          })
+          .then(users => {
+            users.forEach((user) => {
+              [].push(user)
+            });
+            resolve(users);
+          })
+          .catch(xhr => {
+            alert(tr('somethingWentWrong'));
+            reject();
+          })
+      });
 
-              let list_html = `<table>
+      const buildTable = users => {
+        let list_html = `<table>
                     <thead>
                       <tr>
-                        <th>${translatedEmailAddress}</th>
-                        <th>${translatedDeleteUser}</th>
+                        <th>${tr('emailAddress')}</th>
+                        <th>${tr('deleteUser')}</th>
                       </tr>
                     </thead>`;
 
-              // Add each user to the table
+        users.forEach((user) => {
+          list_html += `<tbody id='user-table'>
+                    <tr>
+                      <td>
+                        ${user.email}
+                      </td>
+                      <td>
+                        <button class='delete' data-id='${user.id}'>
+                          ${translatedDeleteButton}
+                        </button>
+                      </td>
+                    </tr>`;
+        });
 
-              users.forEach((user) => {
-                  list_html += `<tbody id='user-table'>
-                        <tr>
-                          <td>${user.email}</td>
-                          <td>
-                            <button class='delete' data-id='${user.id}'>${translatedDeleteButton}</button>
-                          </td>
-                        </tr>`;
-                  allUsers.push(user.email);
-              })
+        list_html += '</tbody></table>';
+        $('.user-list').html(list_html);
+      };
 
-              list_html += '</tbody></table>';
-              $('.user-list').html(list_html);
+      getUsers().then(buildTable);
+
+      const deleteUser = (e) => {
+        const target = (e.target) ? e.target : e.srcElement;
+        const id = $(target)[0].attributes['data-id'].value;
+
+        if (confirm(tr('confirmText'))) {
+          $.ajax({
+            type: 'DELETE',
+            contentType: 'application/json',
+            url: `/admin/api/site_users/${id}`,
+            dataType: 'json'
+          }).then(function () {
+            getUsers().then(buildTable);
+            alert(tr('userDeleted'))
           }).catch(function () {
-              alert(translatedSomethingWentWrong);
-          });;
+            alert(tr('somethingWentWrong'));
+          });
+        }
       }
 
-      getUsers();
-
-      /* Delete the user and renew the table */
-      $(document).on('click', '.delete', function (e) {
-
-          let entry = $(this).parent().parent(); // Choose the row of the table
-
-          let id = $(this)[0].attributes['data-id'].value; // Get the User ID from the delete button
-
-          if (confirm(translatedConfirmText)) {
-              $.ajax({
-                  type: 'DELETE',
-                  contentType: 'application/json',
-                  url: '/admin/api/site_users/' + id,
-                  dataType: 'json'
-              }).then(function () {
-                  entry.remove();
-                  alert(translatedUserDeleted)
-              }).catch(function () {
-                  alert(translatedSomethingWentWrong);
-              });
-          }
+      const init = () => $(document).ready(() => {
+        $('#search').on('keyup', searchTable);
+        $(document).on('click', '.delete', deleteUser);
+        $(document).on('click', '#add-user', addUser);
       });
 
-      /* Add an user and renew the table */
-      $(document).on('click', "#add-user", function (e) {
-
-          let emailAddressToAdd = $('#email-to-add')[0].value; // Get the email from the input
-          const regexp = /^([\w\d._\-#])+@([\w\d._\-#]+[.][\w\d._\-#]+)+$/; // Validate e-mail address
-
-          if (emailAddressToAdd === '') {
-              alert(translatedUserNotInserted);
-          } else if (emailAddressToAdd.match(regexp)) {
-              $.ajax({
-                  type: 'POST',
-                  contentType: 'application/json',
-                  url: '/admin/api/site_users',
-                  dataType: 'json',
-                  data: `{\"email\" : \"${emailAddressToAdd}\"}`,
-              }).then(function () {
-                  alert(translatedUserAdded)
-                  getUsers();
-              }).catch(function (jqXHR) {
-                  if (jqXHR.status === 422) {
-                      getUsers();
-                      if (allUsers.includes(emailAddressToAdd)) {
-                          alert(translatedUserExists);
-                      }
-                  } else {
-                      alert(translatedSomethingWentWrong);
-                  }
-              });
-          } else {
-              alert(translatedNotValidEmail);
-          }
-      })
+      init();
     </script>
-
-    {% include "javascripts" %}
-
   </body>
 
   </html>

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -42,7 +42,6 @@
         {% assign str_add = "Lisa" %}
         {% assign str_search_email = "Otsi kasutajat sel lehel: " %}
         {% assign str_home = " ← Mine tagasi esilehele" %}
-        {% assign language = 'et' %}
         {% assign str_title = "Parooliga kaitstud lehtede kasutajate haldamine" %}
         {% assign str_email_address = "E-posti aadress" %}
         {% assign str_delete_button = "Kustuta" %}
@@ -52,7 +51,6 @@
         {% assign str_add = "Add" %}
         {% assign str_search_email = "Search for an e-mail on this page: " %}
         {% assign str_home = " ← Go back to front page" %}
-        {% assign language = 'en' %}
         {% assign str_title = "Manage users of password-protected pages" %}
         {% assign str_email_address = "E-mail address" %}
         {% assign str_delete_button = "Delete" %}
@@ -130,7 +128,7 @@
           }
         }
 
-        const tr = key => (translationStrings['{{ language | escape_once }}'] || translationStrings['en'])[key];
+        const tr = key => (translationStrings['{{ editor_locale }}'] || translationStrings['en'])[key];
         const translatedDeleteButton = tr('deleteButton');
 
         const searchTable = (e) => {

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -8,6 +8,15 @@
           font-family: sans-serif;
         }
 
+        a {
+          color: #443df6;
+        }
+
+        h1 {
+          margin: 0;
+          padding: 16px 0 0 16px;
+        }
+
         td,
         th {
           border: 1px solid #dddddd;
@@ -20,41 +29,55 @@
           border-collapse: collapse;
         }
 
+        .text-center {
+          text-align: center;
+        }
+
         #home-button, 
         .user-list, 
         .search-user,
         .add-user {
           padding: 16px;
         }
+
+        .user-pagination {
+          padding-left: 16px;
+        }
+
+        .user-pagination button:not(:first-child) {
+          margin-left: 8px;
+        }
       </style>
 
       <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
       {% if editor_locale == 'et' %}
-        {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
+        {% assign str_add_email = "Lisa e-posti aadress: " %}
         {% assign str_add = "Lisa" %}
-        {% assign str_search_email = "Soovid otsida kasutajat? " %}
+        {% assign str_search_email = "Otsi kasutajat sel lehel: " %}
         {% assign str_insert_email = "Sisesta e-posti aadress" %}
-        {% assign str_home = "Mine tagasi esilehele" %}
+        {% assign str_home = " ← Mine tagasi esilehele" %}
         {% assign language = 'et' %}
-        {% assign str_title = "Parooliga kaitstud lehtede kasutajate kustutamine üle API" %}
+        {% assign str_title = "Parooliga kaitstud lehtede kasutajate haldamine" %}
       {% else %}
         {% assign str_add_email = "Add an e-mail address: " %}
         {% assign str_add = "Add" %}
-        {% assign str_search_email = "Search for an e-mail: " %}
+        {% assign str_search_email = "Search for an e-mail on this page: " %}
         {% assign str_insert_email = "Insert an e-mail" %}
-        {% assign str_home = "Go back to front page" %}
+        {% assign str_home = " ← Go back to front page" %}
         {% assign language = 'en' %}
-        {% assign str_title = "Deleting users of password-protected pages over API" %}
+        {% assign str_title = "Manage users of password-protected pages" %}
       {% endif %}
 
-    </head>
+      <title>{{str_title}}</title>
 
-    <title>{{str_title}}</title>
+    </head>
 
     <body class="content">
 
       <a href="/" id="home-button">{{ str_home | escape_once }}</a>
+
+      <h1>{{ str_title }}</h1>
 
       <div class="container">
 
@@ -71,12 +94,14 @@
             <input type="submit" value="{{ str_add | escape_once }}" id="add-user"><br>
           </div>
 
+          
 
           <div class="search-user">
             <label for="search">{{ str_search_email | escape_once }}</label>
             <input id="search" type="text" placeholder="{{ str_insert_email | escape_once }}" />
           </div>
 
+          <div class="user-pagination"></div>
           <div class="user-list"></div>
 
       </div>
@@ -92,7 +117,9 @@
             userAdded: 'Kasutaja lisatud!',
             userNotInserted: "E-posti aadressi ei ole sisestatud!",
             notCorrectOrAlreadyExists: "E-posti aadress pole korrektne või on juba lisatud!",
-            somethingWentWrong: "Midagi läks valesti, proovi uuesti!"
+            somethingWentWrong: "Midagi läks valesti, proovi uuesti!",
+            userActivated: "Aktiveeritud",
+            str_page: "Leht"
           },
           'en': {
             emailAddress: 'E-mail address',
@@ -103,7 +130,9 @@
             userAdded: 'User added!',
             userNotInserted: "E-mail address is not inserted",
             notCorrectOrAlreadyExists: "The entered e-mail address is not valid or already exists!",
-            somethingWentWrong: "Something went wrong, try again!"
+            somethingWentWrong: "Something went wrong, try again!",
+            userActivated: "Activated",
+            str_page: "Page"
           }
         }
 
@@ -135,7 +164,7 @@
               })
               .then(function () {
                 alert(tr('userAdded'))
-                getUsers().then(buildTable);
+                getUsers(1).then((obj) => { buildTable(obj.users);});
               })
               .catch(function (xhr) {
                 if (typeof xhr.responseJSON.errors.email !== 'undefined') {
@@ -147,28 +176,32 @@
           }
         }
 
-        const getUsers = () => new Promise((resolve, reject) => {
+        const getUsers = (pageNumber) => new Promise((resolve, reject) => {
           $.ajax({
               type: 'GET',
               contentType: 'application/json',
-              url: '/admin/api/site_users',
-              dataType: 'json'
+              url: `/admin/api/site_users?s=site_user.email&per_page=250&page=${pageNumber}`,
+              dataType: 'json',
             })
-            .then(users => {
-              resolve(users);
+            .then((users, status, xhr) => {
+              const nPages = parseInt(xhr.getResponseHeader('X-Total-Pages'));
+              const obj = {users: users, pages: nPages}
+              buildTable(users);
+              resolve(obj);
             })
             .catch(xhr => {
               alert(tr('somethingWentWrong'));
               reject();
-            })
+            });
         });
 
         const buildTable = users => {
-          let list_html = `<table>
+          let list_html = `<table id='user-table-table'>
                       <thead>
                         <tr>
                           <th>${tr('emailAddress')}</th>
                           <th>${tr('deleteUser')}</th>
+                          <th>${tr('userActivated')}</th>
                         </tr>
                       </thead>
                         <tbody id='user-table'>`;
@@ -176,10 +209,13 @@
           users.forEach((user) => {
             list_html += `<tr>
                             <td>${user.email}</td>
-                            <td>
+                            <td class='text-center'>
                               <button class='delete' data-id='${user.id}'>
                                 ${translatedDeleteButton}
                               </button>
+                            </td>
+                            <td class='text-center'>
+                              ${user.status === 'active' ? '\u2713' : '\u2717'}
                             </td>
                           </tr>`;
           });
@@ -207,9 +243,18 @@
             });
           }
         }
-
+        
         const init = () => $(document).ready(() => {
-          getUsers().then(buildTable);
+
+          getUsers(1).then((obj) => {
+            const num = obj.pages;
+            let container = $('<div />')
+            for (let i = 1; i <= num; i++) {
+              container.append(`<button class='pagination-button' onclick="getUsers(${i})">${tr('str_page')} ${i}</button>`);
+            }
+            $('.user-pagination').html(container);
+          });
+          
           $('#search').on('keyup', searchTable);
           $(document).on('click', '.delete', deleteUser);
           $(document).on('click', '#add-user', addUser);

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -1,0 +1,186 @@
+{% if editmode %}
+  <!DOCTYPE html>
+  {% include "template-variables" %}
+  <html class="{% if editmode %}editmode{% else %}public{% endif %}" lang="{{ page.language_code }}">
+
+  <head prefix="og: http://ogp.me/ns#">
+    {% include "html-head" %}
+    <style>
+      .container .content {
+        font-size: 16px;
+      }
+
+      td,
+      th {
+        border: 1px solid #dddddd;
+        padding: 8px;
+        text-align: center;
+      }
+
+      table {
+        table-layout: fixed;
+        border-collapse: collapse;
+        width: 50%;
+      }
+
+      .userList {
+        padding-top: 16px;
+      }
+
+      .searchForUser {
+        padding-top: 32px;
+      }
+    </style>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  </head>
+
+  <body class="content-page{% if editmode or site.has_many_languages? %} lang-enabled{% endif %} {% if flags_state %}flags-enabled{% else %}flags-disabled{% endif %}">
+
+    <div class="container">
+      {% include "header" %}
+      <section class="content-header content-formatted cfx" data-search-indexing-allowed="true"></section>
+      <main class="content" role="main">
+        
+        <div class="addUser">
+          <label for="email">
+            {% if editor_locale == 'et'%}Soovid lisada e-posti aadressi?:{% else %}Add an e-mail address:{% endif %}
+          </label>
+
+          <input 
+            type="email" 
+            id="emailToBeAdded" 
+            name="email" 
+            placeholder="kasutaja@email.com"
+          >
+
+          <input 
+            type="submit" 
+            value="{% if page.language_code == 'et'%}Lisa{% else %}Add{% endif %}" 
+            id="addUser"
+          ><br>
+
+        </div>
+
+        <div class="searchForUser">
+          <label for="search">
+            {% if editor_locale == 'et'%}Soovid otsida kasutajat?:{% else %}Search for an e-mail:{% endif %}
+          </label>
+          <input 
+            id="search" 
+            type="text" 
+            placeholder="{% if editor_locale == 'et' %}Sisesta e-posti aadress{% else %}Insert an e-mail{% endif %}"
+          />
+        </div>
+        <div class="userList"></div>
+      </main>
+      {% include "footer" %}
+    </div>
+
+
+    <script>
+      const language = document.getElementsByTagName('html')[0].getAttribute('lang');
+
+      let emailTable = 'E-posti aadress'
+      let addButton = 'Lisa'
+      let deleteUser = 'Kustuta kasutaja'
+      let deleteButton = 'Kustuta'
+      let confirmText = 'Oled sa kindel, et soovid seda kasutajat kustutada?'
+      let userDeleted = 'Kasutaja kustutatud!'
+      let userExists = 'Kasutaja on juba olemas!'
+      let userAdded = 'Kasutaja lisatud!'
+      if (language == 'en') {
+          emailTable = 'E-mail address'
+          addButton = 'Add'
+          deleteUser = 'Delete user'
+          deleteButton = 'Delete'
+          confirmText = 'Are you sure you want to delete this account?'
+          userDeleted = 'User deleted!'
+          userExists = 'User already exists!'
+          userAdded = 'User added!'
+      }
+
+      /* Tabeli filtreerimine ja otsing */
+      $(document).ready(function () {
+        $("#search").on("keyup", function () {
+
+          let value = $(this).val().toLowerCase();
+
+          $("#userTable tr").filter(function () {
+            $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+          });
+        });
+      });
+
+      /* Lisab kõik kasutajad pärast GET-requesti tabelisse */
+      function getUsers() {
+        $.ajax({
+          type: 'GET',
+          contentType: 'application/json',
+          url: '/admin/api/site_users',
+          dataType: 'json'
+        }).then(function (users) {
+          let list_html = "<table><thead><tr><th>" + emailTable + 
+          "</th><th>" + deleteUser + 
+          "</th></thead>";
+
+          users.forEach((user) => {
+            list_html += "<tbody id='userTable'><tr><td>" + user.email +
+              "</td><td><button class='delete' data-id=" + user.id + 
+              ">" + deleteButton + 
+              "</button></td></tr>";
+          });
+
+          list_html += "</tbody></table>"
+          $(".userList").html(list_html);
+        });
+      }
+      getUsers();
+
+      /* Kustutab kasutaja ja uuendab tabelit */
+      $(document).on('click', '.delete', function (e) {
+
+        let entry = $(this).parent().parent(); // Vali tabeli rida
+
+        let id = $(this)[0].attributes['data-id'].value; // User ID delete nupust
+
+        if (confirm(confirmText)) {
+          $.ajax({
+            type: 'DELETE',
+            contentType: 'application/json',
+            url: '/admin/api/site_users/' + id,
+            dataType: 'json'
+          }).then(function () {
+            entry.remove();
+            alert(userDeleted)
+          });
+        }
+      });
+
+      /* Lisab kasutaja ja uuendab tabelit */
+      $(document).on('click', "#addUser", function (e) {
+
+        let emailAddress = $("#emailToBeAdded")[0].value;
+
+        $.ajax({
+          type: 'POST',
+          contentType: 'application/json',
+          url: '/admin/api/site_users',
+          dataType: 'json',
+          data: "{\"email\" : \"" + emailAddress + "\"}",
+          error: function (jqXHR) {
+            if (jqXHR.status === 422) {
+              alert(userExists)
+            }
+          }
+        }).then(function () {
+          alert(userAdded)
+          getUsers();
+        });
+      })
+    </script>
+  </body>
+
+  </html>
+{% else %}
+  <meta http-equiv="refresh" content="0; url=/" />
+{% endif %}

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -1,12 +1,11 @@
 {% if editmode %}
   <!DOCTYPE html>
-  {% include "template-variables" %}
-  <html class="{% if editmode %}editmode{% else %}public{% endif %}" lang="{{ page.language_code }}">
+  <html class="editmode" lang="{{ page.language_code }}">
     <head prefix="og: http://ogp.me/ns#">
-      {% include "html-head" %}
       <style>
-        .container .content {
+        .content {
           font-size: 16px;
+          font-family: sans-serif;
         }
 
         td,
@@ -21,68 +20,66 @@
           border-collapse: collapse;
         }
 
-        .user-list {
-          padding-top: 16px;
-        }
-
-        .search-user {
-          padding-top: 32px;
+        #home-button, 
+        .user-list, 
+        .search-user,
+        .add-user {
+          padding: 16px;
         }
       </style>
 
-      {% if editmode or site.has_many_languages? %}
-        {% assign lang-enabled = "lang-enabled" %}
-      {% endif %}
-
-      {% if flags_state %}
-        {% assign flags="flags-enabled" %}
-      {% else %}
-        {% assign flags="flags-disabled" %}
-      {% endif %}
+      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 
       {% if editor_locale == 'et' %}
         {% assign str_add_email = "Soovid lisada e-posti aadressi? " %}
         {% assign str_add = "Lisa" %}
         {% assign str_search_email = "Soovid otsida kasutajat? " %}
         {% assign str_insert_email = "Sisesta e-posti aadress" %}
+        {% assign str_home = "Mine tagasi esilehele" %}
+        {% assign language = 'et' %}
+        {% assign str_title = "Parooliga kaitstud lehtede kasutajate kustutamine üle API" %}
       {% else %}
         {% assign str_add_email = "Add an e-mail address: " %}
         {% assign str_add = "Add" %}
         {% assign str_search_email = "Search for an e-mail: " %}
         {% assign str_insert_email = "Insert an e-mail" %}
+        {% assign str_home = "Go back to front page" %}
+        {% assign language = 'en' %}
+        {% assign str_title = "Deleting users of password-protected pages over API" %}
       {% endif %}
 
     </head>
 
-    <body class="content-page {{ lang-enabled }} {{ flags }}">
+    <title>{{str_title}}</title>
+
+    <body class="content">
+
+      <a href="/" id="home-button">{{ str_home | escape_once }}</a>
+
       <div class="container">
-        {% include "header" %}
-
-        <section class="content-header content-formatted cfx"></section>
-
-        <main class="content" role="main">
 
           <div class="add-user">
-            <label for="email">{{ str_add_email }}</label>
-            <input type="email" id="email-to-add" name="email" placeholder="email@email.com">
+            <label for="email">{{ str_add_email | escape_once }}</label>
+            <input 
+              type="email" 
+              id="email-to-add" 
+              name="email" 
+              placeholder="email@email.com" 
+              required
+            >
 
-            <input type="submit" value="{{ str_add }}" id="add-user"><br>
+            <input type="submit" value="{{ str_add | escape_once }}" id="add-user"><br>
           </div>
 
 
           <div class="search-user">
-            <label for="search">{{ str_search_email }}</label>
-            <input id="search" type="text" placeholder="{{ str_insert_email }}" />
+            <label for="search">{{ str_search_email | escape_once }}</label>
+            <input id="search" type="text" placeholder="{{ str_insert_email | escape_once }}" />
           </div>
 
           <div class="user-list"></div>
 
-        </main>
-        {% include "footer" %}
       </div>
-
-      {%- comment -%} Included component name can differ depending on template {%- endcomment -%}
-      {% include "javascripts" %}
 
       <script>
         const translationStrings = {
@@ -112,8 +109,7 @@
           }
         }
 
-        const language = document.getElementsByTagName('html')[0].getAttribute('lang');
-        const tr = key => (translationStrings[language] || {})[key];
+        const tr = key => (translationStrings['{{ language | escape_once }}'] || translationStrings['en'])[key];
 
         const translatedDeleteButton = tr('deleteButton');
 
@@ -148,6 +144,8 @@
                   alert(tr('userExists'));
                 }
               });
+          } else if (!emailAddressToAdd.match(regexp)) {
+            alert(tr('notValidEmail'))
           } else {
             alert(tr('somethingWentWrong'));
           }
@@ -227,5 +225,9 @@
 
   </html>
 {% else %}
-  <meta http-equiv="refresh" content="0; url=/" />
+  <!DOCTYPE html>
+  <head>
+    <title>Redirect</title>
+    <meta http-equiv="refresh" content="0; url=/" />
+  </head>
 {% endif %}

--- a/site-user-management/layouts/api_user_deletion.tpl
+++ b/site-user-management/layouts/api_user_deletion.tpl
@@ -177,7 +177,7 @@
             const nPages = obj.nPages;
 
             for (let i = 1; i <= nPages; i++) {
-              promises.push(getUsersPage(i))
+              promises.push(getUsersPage(i));
             }
 
             Promise.all(promises).then((results) => {


### PR DESCRIPTION
## Kirjeldus

API-päringu abil kuvab antud _layout_ kõiki veebilehe parooliga kaitstud lehtede kasutajaid (nende e-posti aadresse). _Layout_ võimaldab:
* kustutada kasutajaid `DELETE` päringu abil;
* lisada kasutajaid `POST` päringu abil;
* kasutajaid `GET` päringu abil kuvada,
* kasutajaid jQuery filtreerimise abil sorteerida.

Tabel uueneb kasutajaid lisades ja kustutades automaatselt.

## Eesmärk ja kontekst
Eesmärk on lihtsustada kasutajatoe tööd ning võimaldada veebilehe omanikul ise oma kasutajaid hallata. Closes [#536](https://github.com/Edicy/operations/issues/536).

## Testimine
Tähelepanu võiks koodi puhul pöörata:
* koodi loetavusele ja arusaadavusele;
* tõlgete korrektsusele;
* koodistandarditele vastavausele;
* turvalisusele (et väljastpoolt keegi ligi ei saaks),
* sellele, et ei oleks koodi tõttu mingit lihtsat viisi lehte kokku jooksutada.

## Vajalikud lisasammud, et PR oleks *merge*tav
- [x] Kood vastab koodistandarditele (vastab ESLint / Rubocop / SCSS-lint reeglitele)
- [ ] Lisaks koodile on vaja täiendada ka kasutajatoe juhendeid
  - [ ] Juhendeid on täiendatud